### PR TITLE
Environment Indicator 2.6 was released.

### DIFF
--- a/resources/kaffe.make
+++ b/resources/kaffe.make
@@ -107,7 +107,6 @@ projects[wysiwyg][patch][1802394] = https://www.drupal.org/files/wysiwyg-1802394
 projects[devel][subdir] = development
 projects[diff][subdir] = development
 projects[environment_indicator][subdir] = development
-projects[environment_indicator][version] = 2.x-dev
 projects[stage_file_proxy][subdir] = development
 projects[masquerade][subdir] = development
 projects[module_filter][subdir] = development


### PR DESCRIPTION
So we shouldn't be in need of the development release any more.
