### PR TITLE
Use GIT to get the latest deployotron release

### DIFF
--- a/resources/kaffe.make
+++ b/resources/kaffe.make
@@ -109,5 +109,5 @@ libraries[chosen][destination] = libraries
 
 libraries[deployotron][download][type] = git
 libraries[deployotron][download][url] = https://github.com/reload/deployotron.git
-libraries[deployotron][download][branch = 'master'
+libraries[deployotron][download][branch] = 'master'
 libraries[deployotron][destination] = drush


### PR DESCRIPTION
Use GIT to fetch the latest Deployotron instead of having a hard-coded version.
