### PR TITLE
Feature/private folder

### DIFF
--- a/build-drupal
+++ b/build-drupal
@@ -101,6 +101,7 @@ copy_conf_files() {
   cp "$PRELOAD_DIR/resources/circle/circle.yml" .
   cat "$PRELOAD_DIR/resources/git/gitignore" >> .gitignore
   cp "$PRELOAD_DIR/resources/scrutinizer/.scrutinizer.yml" .scrutinizer.yml
+  cp -R "$PRELOAD_DIR/resources/private" .
 }
 
 copy_modules() {
@@ -144,7 +145,7 @@ apply_patches() {
   drush bandaid-patch \
   --home=https://www.drupal.org/node/2477835 \
   --reason="Release link an type for recommended release" \
-  https://www.drupal.org/files/issues/update_rules-release_link_for_recommended_release-2477835-11.patch \
+  https://www.drupal.org/files/issues/update_rules-release_link_for_recommended_release-2477835-6.patch \
   sites/all/modules/contrib/update_rules
 }
 

--- a/resources/private/.htaccess
+++ b/resources/private/.htaccess
@@ -1,0 +1,1 @@
+deny from all

--- a/resources/private/README.md
+++ b/resources/private/README.md
@@ -1,0 +1,19 @@
+# Private folder
+
+This folder is protected by Apache and cannot be accessed via the
+webserver.
+
+Use this to place non-public files that must be part of the
+repository.
+
+The folder was chosen because this is the only protected part in
+Pantheons nginx configuration and we might as well standardize on
+that.
+
+Be sure to add it to the `nginx` configuration if you host the site
+with nginx elsewhere:
+
+    location /private {
+      deny all;
+      return 404;
+    }


### PR DESCRIPTION
Add a folder which is protected by Apache and cannot be accessed via the webserver.

Use this to place non-public files that must be part of the repository.

The folder was chosen because this is the only protected part in Pantheons nginx configuration and we might as well standardize on that.

Be sure to add it to the `nginx` configuration if you host the site with nginx elsewhere:

```
location /private {
  deny all;
  return 404;
}
```
