### PR TITLE
Watch partial SASS file changes

### DIFF
--- a/resources/themes/STARTERTHEME/Gruntfile.js
+++ b/resources/themes/STARTERTHEME/Gruntfile.js
@@ -29,7 +29,10 @@ module.exports = function (grunt) {
 
     watch: {
       scss: {
-        files: ['sass/*.scss'],
+        files: [
+          'sass/*.scss',
+          'sass/**/*.scss'
+        ],
         tasks: ['sass']
       },
 


### PR DESCRIPTION
When changing a partial file, the Grunt watcher would not compile the new changes. You have to change the "main" file, importing the changes.
