### PR TITLE
Scrutinizer CI should fail on code style issues.

### DIFF
--- a/resources/scrutinizer/.scrutinizer.yml
+++ b/resources/scrutinizer/.scrutinizer.yml
@@ -37,6 +37,9 @@ tools:
       - theme
       - php
   js_hint: true
+build_failure_conditions:
+  # No new coding style issues allowed.
+  - 'issues.label("coding-style").new.exists'
 before_commands:
   # Remove core files - no need to analyse that.
   - "rm -r includes misc modules scripts themes"


### PR DESCRIPTION
To keep code style issues to a low minimum let Scrutinizer CI report code style violations as build failures.
