### PR TITLE
Scrutinizer CI should fail on all new issues.

### DIFF
--- a/resources/scrutinizer/.scrutinizer.yml
+++ b/resources/scrutinizer/.scrutinizer.yml
@@ -38,8 +38,8 @@ tools:
       - php
   js_hint: true
 build_failure_conditions:
-  # No new coding style issues allowed.
-  - 'issues.label("coding-style").new.exists'
+  # No new issues allowed.
+  - 'issues.new.exists'
 before_commands:
   # Remove core files - no need to analyse that.
   - "rm -r includes misc modules scripts themes"


### PR DESCRIPTION
Fixup of d8851c5ec7bb92f824747f82c031fa872eb294a8.

There is no need to restrict Scrutinizer CI to fail only on new issues
labeled "code-style". Especially because failures from PHP Code Sniffer
is not labeled as "code-style" ...
