### PR TITLE
Set `features_default_export_path` to `sites/all/modules/custom`.

### DIFF
--- a/resources/modules/custom/MODULESHORTHAND_f5/MODULESHORTHAND_f5.info
+++ b/resources/modules/custom/MODULESHORTHAND_f5/MODULESHORTHAND_f5.info
@@ -13,6 +13,7 @@ features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[linkit_profiles][] = default_linkit_profile
 features[variable][] = admin_menu_components
+features[variable][] = features_default_export_path
 features[variable][] = jquery_update_jquery_version
 features[variable][] = pathauto_transliterate
 features[variable][] = scheduler_field_type

--- a/resources/modules/custom/MODULESHORTHAND_f5/MODULESHORTHAND_f5.strongarm.inc
+++ b/resources/modules/custom/MODULESHORTHAND_f5/MODULESHORTHAND_f5.strongarm.inc
@@ -27,6 +27,13 @@ function MODULESHORTHAND_f5_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'features_default_export_path';
+  $strongarm->value = 'sites/all/modules/custom';
+  $export['features_default_export_path'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'jquery_update_jquery_version';
   $strongarm->value = '1.8';
   $export['jquery_update_jquery_version'] = $strongarm;


### PR DESCRIPTION
The default value in features is `sites/all/modules`.

So each time a developer creates a new feature one must manually add `sites/all/modules/custom` if generating the feature from the web UI.

That leaves an entry in the `.info` file:

```
project path = sites/all/modules/custom
```

The entry is not really needed and makes it harder to actually move a module to a different location.

So let's just configure a default export path for features and never be bother with it again.
