### PR TITLE
Remove Modernizr and matchMedia from .eslintrc globals.

### DIFF
--- a/resources/scrutinizer/.eslintrc
+++ b/resources/scrutinizer/.eslintrc
@@ -6,8 +6,6 @@
   "globals": {
     "Drupal": true,
     "jQuery": true,
-    "matchMedia": true,
-    "Modernizr": true,
     "CKEDITOR": true
   },
   "rules": {


### PR DESCRIPTION
We don't use them in pReload so it's wrong to list them as globals.
