### PR TITLE
Fix eslint installation on Scrutinizer CI

### DIFF
--- a/resources/scrutinizer/.scrutinizer.yml
+++ b/resources/scrutinizer/.scrutinizer.yml
@@ -44,7 +44,7 @@ build_failure_conditions:
   - 'issues.new.exists'
 before_commands:
   # Install an up-to-date eslint.
-  - 'cd /usr/share/scrutinizer && npm install eslint'
+  - 'npm install -g eslint'
   # Remove core files - no need to analyse that.
   - "rm -r includes misc modules scripts themes"
   - "rm -r profiles/minimal profiles/standard profiles/testing"


### PR DESCRIPTION
Scrutinizer CI changed something in their setup so we will have to
install eslint as a global npm command to make the check work.
