### PR TITLE
Remove PHPCPD from Scrutinizer

### DIFF
--- a/resources/scrutinizer/.scrutinizer.yml
+++ b/resources/scrutinizer/.scrutinizer.yml
@@ -10,15 +10,6 @@ tools:
       - theme
     config:
       standard: Drupal
-  php_cpd:
-    names:
-      - '*.module'
-      - '*.inc'
-      - '*.install'
-      - '*.test'
-      - '*.profile'
-      - '*.theme'
-      - '*.php'
   php_loc:
     names:
       - '*.module'


### PR DESCRIPTION
Scrutinizer already runs a PHP Similarity Analyser and complains about these two running at the same time.
